### PR TITLE
Expose contrast and sharpness settings

### DIFF
--- a/FlipTrack/Models/Configuration.swift
+++ b/FlipTrack/Models/Configuration.swift
@@ -5,4 +5,6 @@ struct Configuration: Codable {
     var qualityMode = true
     var filterImage = false
     var filterStrength = Float(0.5)
+    var contrast = Float(1.5)
+    var sharpness = Float(0.5)
 }

--- a/FlipTrack/Tools/Extensions.swift
+++ b/FlipTrack/Tools/Extensions.swift
@@ -92,7 +92,9 @@ extension NumberFormatter {
 }
 
 extension CIImage {
-    func preprocessImage(strength: Float = 0.5) -> CIImage {
+    func preprocessImage(strength: Float = 0.5,
+                         contrast: Float = 1.5,
+                         sharpness: Float = 0.5) -> CIImage {
         let colorMatrix = CIFilter(name: "CIColorMatrix")!
         colorMatrix.setValue(self, forKey: kCIInputImageKey)
         colorMatrix.setValue(CIVector(x: 1 + strength, y: 0, z: 0, w: 0), forKey: "inputRVector")
@@ -101,7 +103,7 @@ extension CIImage {
 
         let colorControls = CIFilter(name: "CIColorControls")!
         colorControls.setValue(colorMatrix.outputImage, forKey: kCIInputImageKey)
-        colorControls.setValue(1.5, forKey: kCIInputContrastKey)
+        colorControls.setValue(contrast, forKey: kCIInputContrastKey)
         colorControls.setValue(0.0, forKey: kCIInputSaturationKey)
 
         let medianFilter = CIFilter(name: "CIMedianFilter")!
@@ -109,7 +111,7 @@ extension CIImage {
 
         let sharpenFilter = CIFilter(name: "CISharpenLuminance")!
         sharpenFilter.setValue(medianFilter.outputImage, forKey: kCIInputImageKey)
-        sharpenFilter.setValue(0.5, forKey: kCIInputSharpnessKey)
+        sharpenFilter.setValue(sharpness, forKey: kCIInputSharpnessKey)
 
         return sharpenFilter.outputImage!
     }

--- a/FlipTrack/Tools/Scanner.swift
+++ b/FlipTrack/Tools/Scanner.swift
@@ -21,7 +21,10 @@ class Scanner {
             guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
             let rawImage = CIImage(cvPixelBuffer: pixelBuffer)
             let filteredImage = store.config.filterImage
-                ? rawImage.preprocessImage(strength: store.config.filterStrength)
+                ? rawImage.preprocessImage(
+                    strength: store.config.filterStrength,
+                    contrast: store.config.contrast,
+                    sharpness: store.config.sharpness)
                 : rawImage
             let requestHandler = VNImageRequestHandler(ciImage: filteredImage, options: [:])
             let textRequest = VNRecognizeTextRequest { request, error in

--- a/FlipTrack/Views/PreferencesView.swift
+++ b/FlipTrack/Views/PreferencesView.swift
@@ -30,6 +30,14 @@ struct PreferencesView: View {
                         Text("Filter Strength: \(String(format: "%.1f", configStore.config.filterStrength))")
                         Slider(value: $configStore.config.filterStrength, in: 0...1)
                     }
+                    HStack {
+                        Text("Contrast: \(String(format: "%.1f", configStore.config.contrast))")
+                        Slider(value: $configStore.config.contrast, in: 0.5...3)
+                    }
+                    HStack {
+                        Text("Sharpness: \(String(format: "%.1f", configStore.config.sharpness))")
+                        Slider(value: $configStore.config.sharpness, in: 0...2)
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add `contrast` and `sharpness` values to `Configuration`
- parameterize image preprocessing with new values
- forward the configuration in `Scanner`
- expose sliders for contrast and sharpness in preferences

## Testing
- `swift build` *(fails: Could not find Package.swift)*